### PR TITLE
fix for React Warning

### DIFF
--- a/pages/pet-detail-page/[id].js
+++ b/pages/pet-detail-page/[id].js
@@ -80,9 +80,9 @@ const StyledInteractionImage = styled(Image)`
   top: 0;
   right: 30%;
   animation: ${(props) => {
-      if (props.animationStyle === "sleeping") return sleepingAnimation;
-      if (props.animationStyle === "toy") return toyAnimation;
-      if (props.animationStyle === "food") return foodAnimation;
+      if (props.animationstyle === "sleeping") return sleepingAnimation;
+      if (props.animationstyle === "toy") return toyAnimation;
+      if (props.animationstyle === "food") return foodAnimation;
     }}
     1s ease-in-out infinite;
 `;
@@ -413,7 +413,7 @@ export default function PetDetailPage({
                   alt="interaction icon"
                   height={50}
                   width={50}
-                  animationStyle={isInteracting.interaction}
+                  animationstyle={isInteracting.interaction}
                 />
               )}
               <StyledPetImage

--- a/pages/pet-detail-page/[id].js
+++ b/pages/pet-detail-page/[id].js
@@ -80,9 +80,9 @@ const StyledInteractionImage = styled(Image)`
   top: 0;
   right: 30%;
   animation: ${(props) => {
-      if (props.animationstyle === "sleeping") return sleepingAnimation;
-      if (props.animationstyle === "toy") return toyAnimation;
-      if (props.animationstyle === "food") return foodAnimation;
+      if (props.$animationstyle === "sleeping") return sleepingAnimation;
+      if (props.$animationstyle === "toy") return toyAnimation;
+      if (props.$animationstyle === "food") return foodAnimation;
     }}
     1s ease-in-out infinite;
 `;
@@ -413,7 +413,7 @@ export default function PetDetailPage({
                   alt="interaction icon"
                   height={50}
                   width={50}
-                  animationstyle={isInteracting.interaction}
+                  $animationstyle={isInteracting.interaction}
                 />
               )}
               <StyledPetImage


### PR DESCRIPTION
Fix for: _Warning: React does not recognize the `animationStyle` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `animationstyle` instead. If you accidentally passed it from a parent component, remove it from the DOM element._